### PR TITLE
Fix duplicate patch color

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
@@ -151,7 +151,7 @@
     { name: "Purple", cmyk: [50, 100, 0, 0] },
     { name: "Lime", cmyk: [50, 0, 100, 0] },
     { name: "Teal", cmyk: [100, 0, 50, 0] },
-    { name: "Pink", cmyk: [0, 50, 0, 0] },
+    { name: "Pink", cmyk: [0, 50, 10, 0] },
     { name: "Brown", cmyk: [30, 75, 100, 15] },
     
     // Gray Scale (10)


### PR DESCRIPTION
## Summary
- adjust pink patch CMYK values so each calibration patch is unique

## Testing
- `node - <<'EOF'
const fs=require('fs');
const str=fs.readFileSync('ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html','utf8');
const match=str.match(/const PATCHES = \[(.*?)\];/s);
const patches = eval('[' + match[1].replace(/\/\/.*$/gm,'') + ']');
const dupes=patches.filter((p,i)=>patches.findIndex(pp=>pp.cmyk.toString()==p.cmyk.toString())!=i);
console.log('dupes',dupes);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684c9fd846bc832cb0d2855a0dc45b04