### PR TITLE
Use measured LAB data when available

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
@@ -490,52 +490,59 @@
     // CRITICAL: Predict CMYK adjustments using trained models
     async predictCMYKAdjustment(targetLab, printedLab, currentCmyk) {
       console.log('🔍 Predicting CMYK adjustment:', { targetLab, printedLab, currentCmyk });
-      
+
       try {
+        // Determine if we have a valid measurement
+        const hasMeasurement = printedLab && printedLab.some(v => v !== 0);
         let predictedLab = [...printedLab];
 
-        // Use neural network if available and trained
-        if (this.neuralModel && this.modelStats.neuralNetworkActive) {
-          console.log('🧠 Using neural network for prediction');
-          const features = [
-            ...currentCmyk,
-            ...targetLab,
-            currentCmyk[0] + currentCmyk[1] + currentCmyk[2] + currentCmyk[3],
-            Math.abs(targetLab[1]) + Math.abs(targetLab[2])
-          ];
-          
-          const input = tf.tensor2d([features]);
-          const prediction = this.neuralModel.predict(input);
-          const predictionData = await prediction.data();
-          predictedLab = Array.from(predictionData);
-          
-          input.dispose();
-          prediction.dispose();
-        } else if (this.linearModel && this.linearModel.length === 3) {
-          console.log('📊 Using linear model for prediction');
-          // Use linear model fallback
-          const features = [
-            1, // bias
-            ...currentCmyk,
-            ...targetLab,
-            currentCmyk[0] * targetLab[0],
-            currentCmyk[1] * targetLab[1],
-            currentCmyk[2] * targetLab[2],
-            currentCmyk[3] * targetLab[0],
-            currentCmyk[0] * currentCmyk[0],
-            currentCmyk[1] * currentCmyk[1],
-            currentCmyk[2] * currentCmyk[2],
-            currentCmyk[3] * currentCmyk[3]
-          ];
+        if (!hasMeasurement) {
+          // No measurement yet, use prediction models
+          if (this.neuralModel && this.modelStats.neuralNetworkActive) {
+            console.log('🧠 Using neural network for prediction');
+            const features = [
+              ...currentCmyk,
+              ...targetLab,
+              currentCmyk[0] + currentCmyk[1] + currentCmyk[2] + currentCmyk[3],
+              Math.abs(targetLab[1]) + Math.abs(targetLab[2])
+            ];
 
-          predictedLab = this.linearModel.map(coeff => 
-            coeff.reduce((sum, c, i) => sum + c * (features[i] || 0), 0)
-          );
+            const input = tf.tensor2d([features]);
+            const prediction = this.neuralModel.predict(input);
+            const predictionData = await prediction.data();
+            predictedLab = Array.from(predictionData);
+
+            input.dispose();
+            prediction.dispose();
+          } else if (this.linearModel && this.linearModel.length === 3) {
+            console.log('📊 Using linear model for prediction');
+            // Use linear model fallback
+            const features = [
+              1, // bias
+              ...currentCmyk,
+              ...targetLab,
+              currentCmyk[0] * targetLab[0],
+              currentCmyk[1] * targetLab[1],
+              currentCmyk[2] * targetLab[2],
+              currentCmyk[3] * targetLab[0],
+              currentCmyk[0] * currentCmyk[0],
+              currentCmyk[1] * currentCmyk[1],
+              currentCmyk[2] * currentCmyk[2],
+              currentCmyk[3] * currentCmyk[3]
+            ];
+
+            predictedLab = this.linearModel.map(coeff =>
+              coeff.reduce((sum, c, i) => sum + c * (features[i] || 0), 0)
+            );
+          } else {
+            console.log('🎨 Using color theory fallback');
+          }
         } else {
-          console.log('🎨 Using color theory fallback');
+          // Measured LAB values available; skip prediction
+          console.log('📏 Using measured LAB values for error calculation');
         }
 
-        // Calculate LAB error
+        // Calculate LAB error using either prediction or measurement
         const labError = [
           targetLab[0] - predictedLab[0], // ΔL
           targetLab[1] - predictedLab[1], // Δa


### PR DESCRIPTION
## Summary
- detect if printed LAB values contain real data
- skip neural/linear prediction when measurements are present
- keep existing prediction models for the first iteration

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ccad802a4832cbc1aa54e9fa30e53