### PR TITLE
Use measurement if available

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.6.html
@@ -490,57 +490,71 @@
     // CRITICAL: Predict CMYK adjustments using trained models
     async predictCMYKAdjustment(targetLab, printedLab, currentCmyk) {
       console.log('🔍 Predicting CMYK adjustment:', { targetLab, printedLab, currentCmyk });
-      
+
       try {
+        const hasMeasurement = printedLab && printedLab.some(v => v !== 0);
         let predictedLab = [...printedLab];
+        let labError;
+        let methodUsed = 'Measurement';
 
-        // Use neural network if available and trained
-        if (this.neuralModel && this.modelStats.neuralNetworkActive) {
-          console.log('🧠 Using neural network for prediction');
-          const features = [
-            ...currentCmyk,
-            ...targetLab,
-            currentCmyk[0] + currentCmyk[1] + currentCmyk[2] + currentCmyk[3],
-            Math.abs(targetLab[1]) + Math.abs(targetLab[2])
-          ];
-          
-          const input = tf.tensor2d([features]);
-          const prediction = this.neuralModel.predict(input);
-          const predictionData = await prediction.data();
-          predictedLab = Array.from(predictionData);
-          
-          input.dispose();
-          prediction.dispose();
-        } else if (this.linearModel && this.linearModel.length === 3) {
-          console.log('📊 Using linear model for prediction');
-          // Use linear model fallback
-          const features = [
-            1, // bias
-            ...currentCmyk,
-            ...targetLab,
-            currentCmyk[0] * targetLab[0],
-            currentCmyk[1] * targetLab[1],
-            currentCmyk[2] * targetLab[2],
-            currentCmyk[3] * targetLab[0],
-            currentCmyk[0] * currentCmyk[0],
-            currentCmyk[1] * currentCmyk[1],
-            currentCmyk[2] * currentCmyk[2],
-            currentCmyk[3] * currentCmyk[3]
-          ];
+        if (!hasMeasurement) {
+          // Only predict when there is no measurement
+          methodUsed = this.modelStats.neuralNetworkActive ? 'Neural Network' :
+                       (this.linearModel ? 'Linear Model' : 'Color Theory');
 
-          predictedLab = this.linearModel.map(coeff => 
-            coeff.reduce((sum, c, i) => sum + c * (features[i] || 0), 0)
-          );
+          if (this.neuralModel && this.modelStats.neuralNetworkActive) {
+            console.log('🧠 Using neural network for prediction');
+            const features = [
+              ...currentCmyk,
+              ...targetLab,
+              currentCmyk[0] + currentCmyk[1] + currentCmyk[2] + currentCmyk[3],
+              Math.abs(targetLab[1]) + Math.abs(targetLab[2])
+            ];
+
+            const input = tf.tensor2d([features]);
+            const prediction = this.neuralModel.predict(input);
+            const predictionData = await prediction.data();
+            predictedLab = Array.from(predictionData);
+
+            input.dispose();
+            prediction.dispose();
+          } else if (this.linearModel && this.linearModel.length === 3) {
+            console.log('📊 Using linear model for prediction');
+            // Use linear model fallback
+            const features = [
+              1, // bias
+              ...currentCmyk,
+              ...targetLab,
+              currentCmyk[0] * targetLab[0],
+              currentCmyk[1] * targetLab[1],
+              currentCmyk[2] * targetLab[2],
+              currentCmyk[3] * targetLab[0],
+              currentCmyk[0] * currentCmyk[0],
+              currentCmyk[1] * currentCmyk[1],
+              currentCmyk[2] * currentCmyk[2],
+              currentCmyk[3] * currentCmyk[3]
+            ];
+
+            predictedLab = this.linearModel.map(coeff =>
+              coeff.reduce((sum, c, i) => sum + c * (features[i] || 0), 0)
+            );
+          } else {
+            console.log('🎨 Using color theory fallback');
+          }
+
+          labError = [
+            targetLab[0] - predictedLab[0], // ΔL
+            targetLab[1] - predictedLab[1], // Δa
+            targetLab[2] - predictedLab[2]  // Δb
+          ];
         } else {
-          console.log('🎨 Using color theory fallback');
+          // When measurement exists use it directly
+          labError = [
+            targetLab[0] - printedLab[0],
+            targetLab[1] - printedLab[1],
+            targetLab[2] - printedLab[2]
+          ];
         }
-
-        // Calculate LAB error
-        const labError = [
-          targetLab[0] - predictedLab[0], // ΔL
-          targetLab[1] - predictedLab[1], // Δa
-          targetLab[2] - predictedLab[2]  // Δb
-        ];
 
         // Convert LAB error to CMYK adjustments using enhanced color theory
         const cmykAdjustment = this.labErrorToCMYKAdjustment(labError, currentCmyk, targetLab);
@@ -553,8 +567,7 @@
         const result = {
           suggested: suggestedCmyk,
           confidence: this.modelStats.confidence,
-          method: this.modelStats.neuralNetworkActive ? 'Neural Network' : 
-                 this.linearModel ? 'Linear Model' : 'Color Theory',
+          method: methodUsed,
           labError: labError,
           adjustment: cmykAdjustment
         };


### PR DESCRIPTION
## Summary
- use printed LAB data when available in `predictCMYKAdjustment`
- return lab error based on actual measurement

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684ccbf3affc832c923871802403c2c4