### PR TITLE
Fix CMYK adjustment signs

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -629,15 +629,15 @@
       // Red/Green adjustments (a* axis)
       if (Math.abs(deltaA) > 0.5) {
         const aFactor = deltaA * 0.5 * scaleFactor;
-        adjustments[1] -= aFactor; // Magenta primarily affects a*
-        adjustments[0] += aFactor * 0.3; // Cyan secondary effect
+        adjustments[1] += aFactor; // Magenta primarily affects a*
+        adjustments[0] -= aFactor * 0.3; // Cyan secondary effect
       }
 
       // Yellow/Blue adjustments (b* axis)
       if (Math.abs(deltaB) > 0.5) {
         const bFactor = deltaB * 0.5 * scaleFactor;
-        adjustments[2] -= bFactor; // Yellow primarily affects b*
-        adjustments[0] += bFactor * 0.2; // Cyan secondary effect
+        adjustments[2] += bFactor; // Yellow primarily affects b*
+        adjustments[0] -= bFactor * 0.2; // Cyan secondary effect
       }
 
       // Apply learning from historical data if available


### PR DESCRIPTION
## Summary
- correct the direction of `a` and `b` axis adjustments in `labErrorToCMYKAdjustment`

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684d21275244832ca5e6760df8bfb6d0