### PR TITLE
Fix historical adjustment direction

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -681,11 +681,11 @@
             data.targetLab[2] - data.printedLab[2]
           ];
 
-          // Convert error direction to CMYK adjustment direction
-          adjustments[0] += errorDirection[1] * 0.2 * weight; // a* -> Cyan
-          adjustments[1] += -errorDirection[1] * 0.4 * weight; // a* -> Magenta
-          adjustments[2] += -errorDirection[2] * 0.4 * weight; // b* -> Yellow
-          adjustments[3] += -errorDirection[0] * 0.3 * weight; // L* -> Black
+            // Convert error direction to CMYK adjustment direction
+            adjustments[0] -= errorDirection[1] * 0.2 * weight; // a* -> Cyan
+            adjustments[1] += errorDirection[1] * 0.4 * weight; // a* -> Magenta
+            adjustments[2] += errorDirection[2] * 0.4 * weight; // b* -> Yellow
+            adjustments[3] += -errorDirection[0] * 0.3 * weight; // L* -> Black
 
           totalWeight += weight;
         }


### PR DESCRIPTION
## Summary
- correct sign of CMYK adjustment calculations in `calculateHistoricalAdjustment`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684d2130aa84832c9beed546ee45bb00