### PR TITLE
fix fallback adjustment labDiff

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -956,10 +956,10 @@
             if (deltaE > 2) {
               const labDiff = originalLab.map((val, i) => val - printedLab[i]);
               const adjustment = [
-                -labDiff[1] * 0.3, // a* affects magenta/cyan
-                -labDiff[1] * 0.4, // a* primarily affects magenta
-                -labDiff[2] * 0.4, // b* affects yellow
-                -labDiff[0] * 0.3  // L* affects black
+                labDiff[1] * 0.3, // a* affects magenta/cyan
+                labDiff[1] * 0.4, // a* primarily affects magenta
+                labDiff[2] * 0.4, // b* affects yellow
+                labDiff[0] * 0.3  // L* affects black
               ];
               const suggested = cmykInput.map((val, i) => 
                 Math.max(0, Math.min(100, val + adjustment[i]))


### PR DESCRIPTION
## Summary
- update fallback adjustment in calibration HTML

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684d213eb438832cbc4ed0ff4499e7a8