### PR TITLE
Dampen CMYK adjustment suggestions

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -947,7 +947,10 @@
               printedLab,
               cmykInput
             );
-            setSuggestedCmyk(result.suggested);
+            const dampened = result.suggested.map(
+              (v, i) => cmykInput[i] + (v - cmykInput[i]) * 0.5
+            );
+            setSuggestedCmyk(dampened);
             setPredictionDetails(result);
           } catch (error) {
             console.error('❌ Calculation error:', error);
@@ -1265,15 +1268,19 @@
             finalLab,
             currentResult.suggested
           );
-          
+
           console.log('🤖 New AI suggestion generated:', newSuggestion);
-          
+
+          const dampened = newSuggestion.suggested.map(
+            (v, i) => currentResult.suggested[i] + (v - currentResult.suggested[i]) * 0.5
+          );
+
           // Create new iteration data for Color Match tab
           const newIterationData = {
             targetLab: [...currentResult.targetLab],
             printedLab: [...finalLab],
             inputCmyk: [...currentResult.suggested],
-            suggested: [...newSuggestion.suggested],
+            suggested: dampened,
             predictionDetails: newSuggestion,
             iteration: (currentResult.iteration || 1) + 1,
             previousDeltaE: deltaE


### PR DESCRIPTION
## Summary
- dampen AI CMYK suggestions by 50% in Color Match component
- apply same dampening for subsequent iteration suggestions when confirming a print result

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684d323a9534832cb4d715256ef36699