### PR TITLE
Update lint docs and test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,9 @@ repository. It contains the calibration UI and logic for measuring and learning
 color patches to build accurate profiles. The “FIXED” tag denotes improvements
 in handling device data, while version **2.1.8** includes the latest adjustments
 for more reliable color matching.
+
+## Development
+
+The project ships with an ESLint setup that checks HTML files using the
+`eslint-plugin-html` plugin. Run `npm install` to install the required
+development dependencies before invoking `npm run lint`.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node -e \"console.log('No tests specified')\"",
     "lint": "eslint ."
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- document `eslint-plugin-html` setup in README
- prevent `npm test` from exiting with an error

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684d323c4f20832c905a6e755da0d100