### PR TITLE
Add configurable LAB thresholds

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -211,7 +211,13 @@
 
   // Enhanced AI Color Model with proper data flow
   class AIColorModel {
-    constructor() {
+    constructor(options = {}) {
+      const {
+        deltaLThreshold = 0.5,
+        deltaAThreshold = 0.5,
+        deltaBThreshold = 0.5
+      } = options;
+
       this.calibrationData = [];
       this.learningData = [];
       this.realWorldResults = [];
@@ -229,7 +235,11 @@
         successfulMatches: 0,
         totalAttempts: 0
       };
-      
+
+      this.deltaLThreshold = deltaLThreshold;
+      this.deltaAThreshold = deltaAThreshold;
+      this.deltaBThreshold = deltaBThreshold;
+
       console.log('🤖 AIColorModel initialized');
     }
 
@@ -626,7 +636,7 @@
       const scaleFactor = Math.min(2.0, Math.max(0.1, errorMagnitude / 10));
 
       // Lightness adjustments (L* axis)
-      if (Math.abs(deltaL) > 0.5) {
+      if (Math.abs(deltaL) > this.deltaLThreshold) {
         const lightnessFactor = deltaL * 0.4 * scaleFactor;
         
         // Primary adjustment through K (black)
@@ -642,14 +652,14 @@
       }
 
       // Red/Green adjustments (a* axis)
-      if (Math.abs(deltaA) > 0.5) {
+      if (Math.abs(deltaA) > this.deltaAThreshold) {
         const aFactor = deltaA * 0.5 * scaleFactor;
         adjustments[1] += aFactor; // Magenta primarily affects a*
         adjustments[0] -= aFactor * 0.3; // Cyan secondary effect
       }
 
       // Yellow/Blue adjustments (b* axis)
-      if (Math.abs(deltaB) > 0.5) {
+      if (Math.abs(deltaB) > this.deltaBThreshold) {
         const bFactor = deltaB * 0.5 * scaleFactor;
         adjustments[2] += bFactor; // Yellow primarily affects b*
         adjustments[0] -= bFactor * 0.2; // Cyan secondary effect
@@ -1915,7 +1925,11 @@
 
   // CRITICAL: Main App Component with proper state management
   function App() {
-    const aiModelRef = useRef(new AIColorModel());
+    const aiModelRef = useRef(new AIColorModel({
+      deltaLThreshold: 0.5,
+      deltaAThreshold: 0.5,
+      deltaBThreshold: 0.5
+    }));
     const [tab, setTab] = useState('match');
     const [rounds, setRounds] = useState([]);
     const [nextIteration, setNextIteration] = useState(null);

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ color patches to build accurate profiles. The “FIXED” tag denotes improvemen
 in handling device data, while version **2.1.8** includes the latest adjustments
 for more reliable color matching.
 
+## Configuration
+
+The `AIColorModel` accepts optional thresholds for ΔL, Δa and Δb when
+instantiated. These thresholds determine how sensitive the model is when
+converting LAB errors to CMYK adjustments. All three default to `0.5`:
+
+```javascript
+const ai = new AIColorModel({
+  deltaLThreshold: 0.5,
+  deltaAThreshold: 0.5,
+  deltaBThreshold: 0.5
+});
+```
+
+Adjust these values to fine‑tune how aggressively suggestions respond to small
+LAB differences.
+
 ## Development
 
 The project ships with an ESLint setup that checks HTML files using the


### PR DESCRIPTION
## Summary
- allow tuning thresholds for LAB error handling
- use configurable thresholds in `labErrorToCMYKAdjustment`
- pass defaults when initializing `AIColorModel`
- document how to customize thresholds

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684de2155c54832cbb5bee19b199da87