### PR TITLE
Add detailed CMYK adjustment logging

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -586,9 +586,13 @@
         }
 
         // Apply scaled adjustments and clamp final values
-        const suggestedCmyk = currentCmyk.map((v, i) =>
-          clamp(v + cmykAdjustment[i] * s, 0, 100)
-        );
+        const suggestedCmyk = currentCmyk.map((v, i) => {
+          const rawDelta = cmykAdjustment[i] * s;
+          const unclamped = v + rawDelta;
+          const final = clamp(unclamped, 0, 100);
+          console.log({index: i, rawDelta, unclamped, final});
+          return final;
+        });
 
         const result = {
           suggested: suggestedCmyk,


### PR DESCRIPTION
## Summary
- compute raw adjustment and clamp calculation inside `predictCMYKAdjustment`
- log intermediate CMYK adjustment details

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684de219fe58832ca5fe780e01f88c87