### PR TITLE
Retrain neural net after every calibration

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -280,10 +280,8 @@
       // CRITICAL: Save immediately after each addition
       this.saveToStorage();
       
-      // Retrain when we have enough calibration data
-      if (this.calibrationData.length >= 5) {
-        this.trainModel();
-      }
+      // Retrain after every new calibration sample
+      this.trainModel();
       
       return true;
     }
@@ -359,7 +357,7 @@
         this.modelStats.totalSamples = allSamples.length;
         console.log(`🧠 Training on ${allSamples.length} samples (${this.calibrationData.length} calibration + ${this.learningData.length} learning)`);
 
-        if (allSamples.length >= 10) {
+        if (allSamples.length > 0) {
           await this.trainNeuralNetwork(allSamples);
           this.modelStats.neuralNetworkActive = true;
         }


### PR DESCRIPTION
## Summary
- update training logic so calibration samples trigger retraining immediately
- start neural network training with any number of samples

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684df3758f80832c99e04cfd7047deb8