### PR TITLE
Enable AI suggestions with each iteration

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -449,7 +449,6 @@
     // Train linear model fallback
     trainLinearModel(samples) {
       try {
-        if (samples.length < 3) return;
 
         console.log('📊 Training linear model with', samples.length, 'samples');
 
@@ -521,13 +520,11 @@
             console.warn('⚠️ ICC transform failed:', e);
           }
         }
-        // Determine if we have a valid measurement
+        // Always attempt to predict the printed LAB values
         const hasMeasurement = printedLab && printedLab.some(v => v !== 0);
-        let predictedLab = [...printedLab];
+        let predictedLab;
 
-        if (!hasMeasurement) {
-          // No measurement yet, use prediction models
-          if (this.neuralModel && this.modelStats.neuralNetworkActive) {
+        if (this.neuralModel && this.modelStats.neuralNetworkActive) {
             console.log('🧠 Using neural network for prediction');
             const features = [
               ...currentCmyk,
@@ -565,10 +562,14 @@
             );
           } else {
             console.log('🎨 Using color theory fallback');
+            predictedLab = hasMeasurement ? [...printedLab] : [...targetLab];
           }
-        } else {
-          // Measured LAB values available; skip prediction
+        } else if (hasMeasurement) {
           console.log('📏 Using measured LAB values for error calculation');
+          predictedLab = [...printedLab];
+        } else {
+          console.log('🎨 Using color theory fallback');
+          predictedLab = [...targetLab];
         }
 
         // Calculate LAB error using either prediction or measurement
@@ -1934,9 +1935,9 @@
   // CRITICAL: Main App Component with proper state management
   function App() {
     const aiModelRef = useRef(new AIColorModel({
-      deltaLThreshold: 0.5,
-      deltaAThreshold: 0.5,
-      deltaBThreshold: 0.5
+      deltaLThreshold: 0,
+      deltaAThreshold: 0,
+      deltaBThreshold: 0
     }));
     const [tab, setTab] = useState('match');
     const [rounds, setRounds] = useState([]);

--- a/README.md
+++ b/README.md
@@ -49,18 +49,19 @@ for more reliable color matching.
 
 The `AIColorModel` accepts optional thresholds for ΔL, Δa and Δb when
 instantiated. These thresholds determine how sensitive the model is when
-converting LAB errors to CMYK adjustments. All three default to `0.5`:
+converting LAB errors to CMYK adjustments. Starting with version 2.1.9 the
+defaults are **0** so every measured difference can influence the suggested
+CMYK values:
 
 ```javascript
 const ai = new AIColorModel({
-  deltaLThreshold: 0.5,
-  deltaAThreshold: 0.5,
-  deltaBThreshold: 0.5
+  deltaLThreshold: 0,
+  deltaAThreshold: 0,
+  deltaBThreshold: 0
 });
 ```
 
-Adjust these values to fine‑tune how aggressively suggestions respond to small
-LAB differences.
+Adjust these values if you want to dampen very small adjustments. Raising the thresholds makes the model ignore minor LAB differences when calculating CMYK changes.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- always use the AI model to predict printed LAB values
- remove minimum-sample check so linear model trains immediately
- initialize the AI model with zero LAB thresholds
- document new default thresholds

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684dfa86a4c0832c96eeda6f0dd0fcfc