### PR TITLE
Fix prediction fallback

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -560,22 +560,13 @@
             predictedLab = this.linearModel.map(coeff =>
               coeff.reduce((sum, c, i) => sum + c * (features[i] || 0), 0)
             );
+          } else if (hasMeasurement) {
+            console.log('📏 Using measured LAB values for error calculation');
+            predictedLab = [...printedLab];
           } else {
-            // No trained model available
-            if (hasMeasurement) {
-              console.log('📏 Using measured LAB values for error calculation');
-              predictedLab = [...printedLab];
-            } else {
-              console.log('🎨 Using color theory fallback');
-              predictedLab = [...targetLab];
-            }
+            console.log('🎨 Using color theory fallback');
+            predictedLab = [...targetLab];
           }
-        } else if (hasMeasurement) {
-          console.log('📏 Using measured LAB values for error calculation');
-          predictedLab = [...printedLab];
-        } else {
-          console.log('🎨 Using color theory fallback');
-          predictedLab = [...targetLab];
         }
 
         // Calculate LAB error using either prediction or measurement


### PR DESCRIPTION
## Summary
- ensure color predictions use measurement or model before resorting to color theory

## Testing
- `npm run lint` *(fails: Cannot find module 'eslint-plugin-html')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e01fedcd0832c83716e216c6cb556