### PR TITLE
Fix README version info and default thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ for more reliable color matching.
 
 The `AIColorModel` accepts optional thresholds for ΔL, Δa and Δb when
 instantiated. These thresholds determine how sensitive the model is when
-converting LAB errors to CMYK adjustments. Starting with version 2.1.9 the
-defaults are **0** so every measured difference can influence the suggested
-CMYK values:
+converting LAB errors to CMYK adjustments. In version **2.1.8** the
+constructor defaults to **0.5** for each threshold so very small LAB
+differences are ignored by default. To account for every difference,
+override the thresholds to **0** when creating the model:
 
 ```javascript
 const ai = new AIColorModel({


### PR DESCRIPTION
## Summary
- clarify that the main HTML tool is version 2.1.8
- document the constructor defaults of `AIColorModel`

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684e0693a89c832c9c69e9571a2ea1fa