### PR TITLE
Update README with install instructions for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,5 @@ Adjust these values if you want to dampen very small adjustments. Raising the th
 
 The project ships with an ESLint setup that checks HTML files using the
 `eslint-plugin-html` plugin. Run `npm install` to install the required
-development dependencies before invoking `npm run lint`.
+development dependencies such as Jest and ESLint before invoking
+`npm run lint` or `npm test`.


### PR DESCRIPTION
## Summary
- document that `npm install` should be run before running tests
- clarify that devDependencies like Jest and ESLint are pulled in

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find module 'eslint-plugin-html')*

------
https://chatgpt.com/codex/tasks/task_e_684e1d32fb4c832cbfc84d4172d803f2