### PR TITLE
Fix try block structure in predictCMYKAdjustment

### DIFF
--- a/lib/AIColorModel.js
+++ b/lib/AIColorModel.js
@@ -359,7 +359,6 @@ async predictCMYKAdjustment(targetLab, printedLab, currentCmyk) {
           console.log('🎨 Using color theory fallback');
           predictedLab = [...targetLab];
         }
-      }
 
       // Calculate LAB error using either prediction or measurement
       const labError = [
@@ -404,8 +403,8 @@ async predictCMYKAdjustment(targetLab, printedLab, currentCmyk) {
       console.log('✅ Prediction completed:', result);
       return result;
 
-    } catch (error) {
-      console.error('❌ Prediction error:', error);
+    } catch (err) {
+      console.error('❌ Prediction error:', err);
       return {
         suggested: [...currentCmyk],
         confidence: 0,


### PR DESCRIPTION
## Summary
- remove stray closing brace in `predictCMYKAdjustment`
- update catch handler to `catch (err)`

## Testing
- `node -c lib/AIColorModel.js`

------
https://chatgpt.com/codex/tasks/task_e_684e1d2d03e0832c9f518ef74faf0114