### PR TITLE
Fix predictCMYKAdjustment snippet

### DIFF
--- a/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
+++ b/ColorMatcherPro_CALIBRATION_FIXED_v2.1.8.html
@@ -111,7 +111,8 @@
           suggested: suggestedCmyk,
           confidence: this.modelStats.confidence,
           method: this.modelStats.neuralNetworkActive ? 'Neural Network' : 'Linear Model',
-          labError, adjustment: cmykAdjustment
+          labError,
+          adjustment: cmykAdjustment
         };
 
         console.log('✅ Prediction completed:', result);
@@ -122,7 +123,7 @@
         return {
           suggested: [...currentCmyk],
           confidence: 0,
-          method: 'Fallback (error)',
+          method: 'Fallback',
           labError: [0,0,0],
           adjustment: [0,0,0,0]
         };


### PR DESCRIPTION
## Summary
- clean up placeholder block inside HTML version of predictCMYKAdjustment

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e26589310832cbf95c32c1c9687f4